### PR TITLE
Add prettier config and warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,6 @@
   "extends": "skira"
 }
 ```
+
+#### Note
+Some editor plugins for `prettier` will attempt to use the `.prettierrc` file in your project and ignore any other forms of configuration. To use the `prettier` rules for this configuration, make sure your editor plugins support `eslint --fix` and do not have an error warning of a missing `.prettierrc` file.

--- a/index.js
+++ b/index.js
@@ -22,6 +22,17 @@ module.exports = {
     // Import
     'import/prefer-default-export': 'off',
 
+    // Prettier
+    'prettier/prettier': [
+        'error', {
+            singleQuote: true,
+            printWidth: 80,
+            arrowParens: 'avoid',
+            trailingComma: 'all'
+        },
+        {usePrettierrc: false},
+    ],
+
     // Customized errors
     'react/jsx-filename-extension': ['warn', { extensions: ['.js', '.jsx'] }],
     'jsx-a11y/click-events-have-key-events': 1,


### PR DESCRIPTION
It makes sense to have our prettier config integrated with our `eslint` plugin. However, some `prettier` editor plugins don't support this (see `README`).